### PR TITLE
[NSI-130] 웹뷰 헤더, 스타일 코드 수정

### DIFF
--- a/SoongsilNotice/NoticeParser/NoticeParser.swift
+++ b/SoongsilNotice/NoticeParser/NoticeParser.swift
@@ -10,8 +10,65 @@ import Kanna
 
 final class NoticeParser {
     public static let shared: NoticeParser = NoticeParser()
-    private let htmlStart = "<hml><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, shrink-to-fit=no\"><style>html,body{padding:0 5px 5px;margin:0;font-size:18px !important;}iframe,img{max-width:100%;height:auto;}</style></head><bpdy>"
-    private let htmlEnd = "</bpdy></hml>"
+    
+    private enum Dimension {
+        enum Margin {
+            static let horizontal = 20
+            static let vertical = 24
+        }
+    }
+    
+    private enum Paragraph {
+        static let fontSize = "16px"
+        static let lineHeight = "1.6"
+        static let textColor = "#333D4B"
+        static let pointColor = "#505782"
+    }
+    
+    private let htmlStart =
+        // special thx to dino han
+        """
+        <head>
+            <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no'>
+        </head>
+        <style>
+            img {
+                height: auto !important;
+                width: auto !important;
+            }
+
+            iframe {
+                width: calc(100vw - \(Dimension.Margin.horizontal*2)px) !important;
+                height: calc((100vw - \(Dimension.Margin.horizontal*2)px)/ 16*9) !important;
+                overflow: scroll;
+            }
+
+            table {
+                width: 100% !important;
+                height: auto !important;
+            }
+
+            body {
+                margin: \(Dimension.Margin.vertical)px \(Dimension.Margin.horizontal)px;
+
+            }
+        
+            * {
+                line-height: \(Paragraph.lineHeight); !important;
+                color: \(Paragraph.textColor); !important;
+                font-size: \(Paragraph.fontSize); !important;
+                font-family: '-apple-system' !important;
+                max-width: 100% !important;
+                -webkit-touch-callout: none;
+            }
+
+            a {
+                color: \(Paragraph.pointColor);
+                word-break: break-all; !important;
+            }
+        </style>
+        """
+    private let htmlEnd = ""
     
     private init() { }
     


### PR DESCRIPTION

![비교](https://user-images.githubusercontent.com/54972653/132876673-2d8c9b89-8651-4971-a196-65f85d5a2bf7.png)


## 📌 Summary
웹뷰에서 로드하는 HTML 코드 앞에 스타일 관련 코드를 추가했습니다


## 💡 Reason
학과별, 공지별 중구난방으로 보이는 화면에 통일감을 부여하기 위해


## 📚 Reference 
[보다 완벽한 webview를 위한 세팅들](https://shylog.com/settings-for-a-more-complete-webview/)