### PR TITLE
[NSI-145] guard문에서 같은 변수 명을 사용해 충돌하는 문제 해결

### DIFF
--- a/SoongsilNotice/ViewControllers/Main/NoticeDetail/NewNoticeDetailViewController.swift
+++ b/SoongsilNotice/ViewControllers/Main/NoticeDetail/NewNoticeDetailViewController.swift
@@ -270,8 +270,8 @@ extension NewNoticeDetailViewController {
     }
     
     private func presentActivityViewController() {
-        guard let url = viewModel.url.value.decodeUrl()?.encodeUrl(),
-              let url = NSURL(string: url) else {
+        guard let urlString = viewModel.url.value.decodeUrl()?.encodeUrl(),
+              let url = NSURL(string: urlString) else {
             YDSToast.makeToast(text: "공유할 수 없는 링크입니다.")
             return
         }


### PR DESCRIPTION
## 📌 Summary
xcode 버전을 13으로 올렸더니 컴파일 과정에서 abort trap 6 에러가 발생했습니다
확인해보니 guard문에서 같은 변수 명을 사용해 충돌하는 문제가 원인이어서 해결했습니다


## 💡 Reason
기존엔 guard 문 안의 두 url 변수가 같은 scope를 공유해서 충돌하는 문제가 있었음
xcode 12에선 문제 없이 빌드 됐으나 13에서 에러가 발생함


## ✍️ Description
- 이슈 티켓 : https://github.com/della-padula/Notissu/issues/145
- 관련 문서 :  
  - [Command failed due to signal: Abort trap: 6](https://stackoverflow.com/questions/30724897/command-failed-due-to-signal-abort-trap-6)  
  - [Why isn't guard let foo = foo valid?](https://stackoverflow.com/questions/40353631/why-isnt-guard-let-foo-foo-valid)
