### PR TITLE
[NSI-144] 순환 참조 문제 해결, 불필요한 Delegate 패턴 삭제

### DIFF
--- a/SoongsilNotice/BaseViewController.swift
+++ b/SoongsilNotice/BaseViewController.swift
@@ -104,7 +104,7 @@ extension UIColor {
     }
 }
 
-protocol ProgressBarDelegate {
+protocol ProgressBarDelegate: AnyObject {
     func showProgressBar()
     func hideProgressBar()
 }

--- a/SoongsilNotice/ViewControllers/Main/NoticeDetail/NewNoticeDetailViewModel.swift
+++ b/SoongsilNotice/ViewControllers/Main/NoticeDetail/NewNoticeDetailViewModel.swift
@@ -24,7 +24,7 @@ protocol NoticeDetailViewModelOutput {
     var attachments: Dynamic<[Attachment]> { get }
     var isBookmarked: Dynamic<Bool> { get }
     var shouldDividerBeHidden: Dynamic<Bool> { get }
-    var fileDownloaderDelegate: FileDownloadDelegate? { get set }
+    var downloadedFilePath: Dynamic<String?> { get }
 }
 
 protocol NoticeDetailViewModelProtocol: NoticeDetailViewModelInput, NoticeDetailViewModelOutput {}
@@ -39,7 +39,7 @@ class NewNoticeDetailViewModel: NoticeDetailViewModelProtocol {
     let attachments: Dynamic<[Attachment]> = Dynamic([])
     let isBookmarked: Dynamic<Bool> = Dynamic(false)
     let shouldDividerBeHidden: Dynamic<Bool> = Dynamic(true)
-    weak var fileDownloaderDelegate: FileDownloadDelegate?
+    var downloadedFilePath: Dynamic<String?> = Dynamic(nil)
     
     //  MARK: - INPUT
     func loadWebView() {
@@ -73,6 +73,7 @@ class NewNoticeDetailViewModel: NoticeDetailViewModelProtocol {
         self.departmentCode = deptCode
         self.isBookmarked.value = isNoticeBookmarked()
     }
+    
 }
 
 //  MARK: - Bookmark
@@ -260,17 +261,7 @@ extension NewNoticeDetailViewModel {
                 print("Download Progress: \(progress.fractionCompleted)")
         }
         .response { response in
-            debugPrint(response)
-            
-            if let filePath = response.fileURL?.path {
-                self.fileDownloaderDelegate?.fileDownloadDidEnd(at: filePath)
-            } else {
-                self.fileDownloaderDelegate?.fileDownloadDidEnd(at: nil)
-            }
+            self.downloadedFilePath.value = response.fileURL?.path
         }
     }
-}
-
-protocol FileDownloadDelegate: AnyObject {
-    func fileDownloadDidEnd(at filePath: String?)
 }

--- a/SoongsilNotice/ViewControllers/Main/NoticeDetail/NewNoticeDetailViewModel.swift
+++ b/SoongsilNotice/ViewControllers/Main/NoticeDetail/NewNoticeDetailViewModel.swift
@@ -39,7 +39,7 @@ class NewNoticeDetailViewModel: NoticeDetailViewModelProtocol {
     let attachments: Dynamic<[Attachment]> = Dynamic([])
     let isBookmarked: Dynamic<Bool> = Dynamic(false)
     let shouldDividerBeHidden: Dynamic<Bool> = Dynamic(true)
-    var fileDownloaderDelegate: FileDownloadDelegate?
+    weak var fileDownloaderDelegate: FileDownloadDelegate?
     
     //  MARK: - INPUT
     func loadWebView() {
@@ -271,6 +271,6 @@ extension NewNoticeDetailViewModel {
     }
 }
 
-protocol FileDownloadDelegate {
+protocol FileDownloadDelegate: AnyObject {
     func fileDownloadDidEnd(at filePath: String?)
 }

--- a/SoongsilNotice/ViewControllers/Main/NoticeDetail/NoticeDetailAttachments/NoticeDetailAttachmentsListTableViewController.swift
+++ b/SoongsilNotice/ViewControllers/Main/NoticeDetail/NoticeDetailAttachments/NoticeDetailAttachmentsListTableViewController.swift
@@ -48,7 +48,6 @@ class NoticeDetailAttachmentsListTableViewController: YDSTableViewController {
         self.tableView.estimatedRowHeight = Dimension.cellHeight
         self.tableView.bounces = false
         self.tableView.isScrollEnabled = false
-        viewModel.fileDownloaderDelegate = self
     }
     
     private func setAutolayouts() {
@@ -62,6 +61,11 @@ class NoticeDetailAttachmentsListTableViewController: YDSTableViewController {
             guard let `self` = self else { return }
             self.tableView.reloadData()
             self.setAutolayouts()
+        }
+        
+        viewModel.downloadedFilePath.bind { [weak self] filePath in
+            guard let `self` = self else { return }
+            self.fileDownloadDidEnd(at: filePath)
         }
     }
 
@@ -97,8 +101,8 @@ extension NoticeDetailAttachmentsListTableViewController {
     }
 }
 
-//  MARK: - FileDownloaderDelegate
-extension NoticeDetailAttachmentsListTableViewController: FileDownloadDelegate, UIDocumentInteractionControllerDelegate {
+//  MARK: - Download file
+extension NoticeDetailAttachmentsListTableViewController: UIDocumentInteractionControllerDelegate {
     func fileDownloadDidEnd(at filePath: String?) {
         if let filePath = filePath {
             self.docController = UIDocumentInteractionController(url: NSURL(fileURLWithPath: filePath) as URL)

--- a/SoongsilNotice/ViewControllers/Main/NoticeDetail/NoticeDetailAttachments/NoticeDetailAttachmentsListTableViewController.swift
+++ b/SoongsilNotice/ViewControllers/Main/NoticeDetail/NoticeDetailAttachments/NoticeDetailAttachmentsListTableViewController.swift
@@ -12,7 +12,7 @@ class NoticeDetailAttachmentsListTableViewController: YDSTableViewController {
     //  MARK: - Property
     private var viewModel: NewNoticeDetailViewModel
     private var docController : UIDocumentInteractionController!
-    var progressBarDelegate: ProgressBarDelegate?
+    weak var progressBarDelegate: ProgressBarDelegate?
     
     
     //  MARK: - Constant

--- a/SoongsilNotice/ViewControllers/Main/NoticesList/View/TableView/NoticesListTableViewController.swift
+++ b/SoongsilNotice/ViewControllers/Main/NoticesList/View/TableView/NoticesListTableViewController.swift
@@ -28,7 +28,7 @@ class NoticesListTableViewController: YDSTableViewController {
             - Dimension.bottomRefreshHeight
     }
     
-    var progressBarDelegate: ProgressBarDelegate?
+    weak var progressBarDelegate: ProgressBarDelegate?
     
     //  MARK: - Init
     init(with viewModel: NoticesListViewModelProtocol) {


### PR DESCRIPTION
## 📌 Summary
Delegate 패턴을 잘못 적용해서 순환 참조 문제가 발생하던 부분을 수정했습니다 (ProgressBarDelegate)
불필요한 Delegate 패턴을 삭제했습니다(FileDownloadDelegate)


## ✍️ Description
- 이슈 티켓 : https://github.com/della-padula/Notissu/issues/144

### Before
<img width="678" alt="스크린샷 2021-09-24 오후 1 26 45" src="https://user-images.githubusercontent.com/54972653/134647155-65b87d21-a5da-4084-aca9-0b972361187e.png">
메모리 사용량이 줄어들지 않고 계속 증가함
<img width="439" alt="스크린샷 2021-09-24 오후 1 32 49" src="https://user-images.githubusercontent.com/54972653/134647221-bcc13b5c-3599-4037-9236-8d7be142b014.png">
디버거로 확인한 결과 공지 디테일 화면이 메모리에서 해제되지 않고 계속해서 남아있음

### After
<img width="575" alt="스크린샷 2021-09-24 오후 5 47 36" src="https://user-images.githubusercontent.com/54972653/134647445-056dfc25-76b8-4fb2-a399-6295e20e906c.png">
Deinit을 Print로 출력해보니 잘 해제됨
<img width="447" alt="스크린샷 2021-09-24 오후 4 35 34" src="https://user-images.githubusercontent.com/54972653/134647503-f058a16b-6aaa-4b49-bc65-924aab38c11c.png">
디버거에서 감지되지 않음
